### PR TITLE
Responsiveness: Fix white space on right side in mobile view

### DIFF
--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -10,7 +10,7 @@ function Main() {
     setDarkMode((current) => !current);
   };
   return (
-    <main className={`${darkMode ? "dark" : ""}`}>
+    <main className={`${darkMode ? "dark" : ""} overflow-x-hidden`}>
       <Nav toggleDarkMode={toggleDarkMode} />
       <Body darkMode={darkMode} />
     </main>


### PR DESCRIPTION
Fixes this white space appearing on mobile devices caused by a nav-bar that's too long.

![image](https://github.com/chrischang5/portfolio/assets/64388914/a998f25b-c334-4d1d-923f-b0a2a0242aca)
